### PR TITLE
Add @lingui/loader to webpack config

### DIFF
--- a/scripts/config-overrides.dev.js
+++ b/scripts/config-overrides.dev.js
@@ -1,3 +1,5 @@
+const path = require('path')
+
 /* eslint-disable */
 module.exports = function(config) {
   // Use your own ESLint file
@@ -25,6 +27,11 @@ module.exports = function(config) {
       'sass-loader',
     ],
   });
+  config.module.rules.push({
+    test: /messages.json$/,
+    include: [path.resolve('src/config/i18n/')],
+    use: '@lingui/loader'
+  })
 
   // Adding the `src` folder to the resolvers, this will
   // allows to import js files using the `src` as root.

--- a/scripts/config-overrides.prod.js
+++ b/scripts/config-overrides.prod.js
@@ -26,6 +26,11 @@ module.exports = function(config) {
       'sass-loader',
     ],
   });
+  config.module.rules.push({
+    test: /messages.json$/,
+    include: [path.resolve('src/config/i18n/')],
+    use: '@lingui/loader'
+  })
 
   // Adding the `src` folder to the resolvers, this will
   // allows to import js files using the `src` as root.

--- a/src/containers/App/App.js
+++ b/src/containers/App/App.js
@@ -2,7 +2,7 @@ import React from 'react';
 import { Router } from '@reach/router';
 import { Home } from 'pages';
 import { I18nProvider } from '@lingui/react';
-import catalogEn from '../../config/i18n/en/messages.js';
+import catalogEn from '../../config/i18n/en/messages.json';
 // import catalogFr from '../../config/i18n/fr/messages.js';
 
 const App = () => {


### PR DESCRIPTION
As discussed on Gitter, this PR adds `@lingui/loader` to webpack config. JSON files imported from `i18n` folder will be automatically compiled using `@lingui/loader`.